### PR TITLE
Method api-http-options

### DIFF
--- a/src/api.lisp
+++ b/src/api.lisp
@@ -162,7 +162,7 @@
   (:documentation "The api class"))
 
 (defgeneric api-http-options (api)
-  (:method api-http-options ((api api-definition))
+  (:method ((api api-definition))
            (setf (hunchentoot:header-out "Server") "Hunchentoot")))
 
 (defgeneric api-dispatch-request (api request)


### PR DESCRIPTION
Method definition had a variable name where you'd expect a method qualifier.
Fixes mmontone/cl-rest-server#14